### PR TITLE
DB 마이그레이션 관련 정보 수정 및 로그 파일 작성 FIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,29 @@
   3. **_arujisama/web_** 디렉토리에서 `npm install` 을 실행하여  
   프로젝트에서 사용된 JavaScript Dependency들을 인스톨합니다.
   
-  4. 프로젝트에 사용할 MySQL Server Connection을 준비해주세요.
+  4. **_arujisama/web_** 디렉토리에서 `npm run build` 를 실행하여 웹을 빌드합니다.
   
-  5. **_arujisama/arujisama_flask/app/config_files_** 디렉토리에  
+  5. 아래의 DB 세팅 과정까지 진행해 주세요.
+  
+  ### 로컬 DB 세팅
+  
+  저희 프로젝트에서 사용할 로컬 데이터베이스를 세팅하는 과정입니다.
+  
+  1. 프로젝트에 사용할 MySQL 혹은 mariaDB를 설치해 주세요.
+  
+  2. ```create database <사용할 데이터베이스 이름>;``` 명령어를 통해 이 프로젝트에 사용할 데이터베이스를 만들어 주세요.
+  
+  3. **_arujisama/arujisama_flask/app/config_files_** 디렉토리에  
   `dbinfo.json`과 `secret_key.json`파일을 다음의 내용으로 추가해주세요.
   
   * **_dbinfo.json_**
   ```{.json}
   {
    "HOST" : "127.0.0.1",
-   "PORT" : "PORT_NUMBER_YOU_WANT",
-   "USER" : "YOUR_MYSQL_CONNECTION_USER",
-   "PWD" : "YOUR_MYSQL_CONNECTION_PASSWORD",
-   "NAME" : "YOUR_MYSQL_CONNECTION_NAME"
+   "PORT" : "3306",
+   "USER" : "MYSQL 로그인 계정",
+   "PWD" : "MYSQL 비밀번호",
+   "NAME" : "사용할 데이터베이스 이름"
   }
    ```
    * **_secret_key.json_**
@@ -47,16 +57,16 @@
   }
   ```
   
-  6. DB Migration을 다음과 같이 진행해주세요.
+  6. arujisama_flask 폴더로 이동 후, 다음 명령어를 통해 DB Migration을 진행해주세요.
   ```
-  python arujisama/arujisama_flask/db_migration.py db init
-  python arujisama/arujisama_flask/db_migration.py db migrate
-  python arujisama/arujisama_flask/db_migration.py db upgrade
+  python db_migration.py db init
+  python db_migration.py db migrate
+  python db_migration.py db upgrade
   ```
   
-  7. **_arujisama/web_** 디렉토리에서 `npm run build` 를 실행하여 웹을 빌드합니다.
+
   
-  8. **_arujisama/arujisama_flask/run.py_** 를 실행하면  
+위 모든 과정을 마친 후, **_arujisama/arujisama_flask/run.py_** 를 실행하면  
   [ARUJISAMA](http://127.0.0.1:3781) 에 접속하실 수 있습니다! 회원가입을 하고 스탬프를 찍어보세요!
   
   

--- a/arujisama_flask/app/__init__.py
+++ b/arujisama_flask/app/__init__.py
@@ -20,7 +20,7 @@ db = SQLAlchemy()
 
 db.init_app(main_app)
 
-from arujisama_flask.app.dbcode import tables
+from .dbcode import tables
 
 migrate = Migrate(main_app, db)
 

--- a/arujisama_flask/app/common/log_writer.py
+++ b/arujisama_flask/app/common/log_writer.py
@@ -1,16 +1,17 @@
 import datetime
 import os
+from pathlib import Path
 
 
 def write_log(log="", ip="not known", id="", func="not known", memo=""):
     current_time = datetime.datetime.now()
 
-    cwd = os.getcwd()
-    directory = str(cwd) + "/app/log/"
-    if not(os.path.isdir(directory)):
-        os.makedirs(os.path.join(directory))
+    BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    directory = os.path.join(BASE_DIR, 'log')
+    if not (os.path.isdir(directory)):
+        Path(directory).mkdir(parents=True, exist_ok=True)
 
-    target_file = directory + "{0}.log".format(current_time.strftime("%Y-%m-%d"))
+    target_file = os.path.join(directory,"{0}.log".format(current_time.strftime("%Y-%m-%d")))
     timestamp = current_time.strftime("%Y-%m-%d %H:%M:%S")
 
     log_message = "{0}) {1}\nip) {2}\nid) {3}\nfunc) {4}\nmemo) {5}\n\n".format(timestamp, log, ip, id, func, memo)

--- a/arujisama_flask/app/dbcode/tables.py
+++ b/arujisama_flask/app/dbcode/tables.py
@@ -1,6 +1,6 @@
-from arujisama_flask.app import db
 from sqlalchemy import Column, ForeignKey
-
+from flask_sqlalchemy import SQLAlchemy
+from .. import db
 
 class UserAccount(db.Model):
     __tablename__ = "user_account"

--- a/arujisama_flask/db_migration.py
+++ b/arujisama_flask/db_migration.py
@@ -1,8 +1,8 @@
 from flask_script import Manager
 from flask_migrate import Migrate, MigrateCommand
-from arujisama_flask.app.config import config_by_name
-from arujisama_flask.app import main_app, db
-from arujisama_flask.app.dbcode.tables import *
+from app.config import config_by_name
+from app import main_app, db
+from app.dbcode.tables import *
 
 
 manager = Manager(main_app)

--- a/arujisama_flask/requirements.txt
+++ b/arujisama_flask/requirements.txt
@@ -1,13 +1,17 @@
+alembic==1.4.1
 atomicwrites==1.3.0
 attrs==19.1.0
 Click==7.0
 colorama==0.4.1
 Flask==1.1.1
 Flask-JWT==0.3.2
+Flask-Migrate==2.5.2
+Flask-Script==2.0.6
 Flask-SQLAlchemy==2.4.0
 importlib-metadata==0.19
 itsdangerous==1.1.0
 Jinja2==2.10.1
+Mako==1.1.2
 MarkupSafe==1.1.1
 more-itertools==7.2.0
 packaging==19.0
@@ -17,6 +21,8 @@ PyJWT==1.4.2
 PyMySQL==0.9.3
 pyparsing==2.4.1.1
 pytest==5.0.1
+python-dateutil==2.8.1
+python-editor==1.0.4
 six==1.12.0
 SQLAlchemy==1.3.6
 wcwidth==0.1.7


### PR DESCRIPTION
0. 1/2번 모두와 연결되는 얘기인데, 현재 import들이 파이참을 통해 루트 폴더에서 실행하는 것을 전제로(즉, 작업 디렉토리는 Arujisama 폴더로 인식) 이루어지고 있습니다. 하지만, migration 같은 경우엔 터미널에서 직접 실행하게 되는데, 이러면 작업 디렉토리의 차이로 임포트문에서 바로 오류가 나게 됩니다. 그래서 db_migration.py를 해당 파일이 있는 폴더에서 직접 실행하도록 하고, 임포트들을 상대경로로 바꾸니 문제 없었습니다. __init__.py가 다 있으니 모듈로 인식도 잘 하고 있습니다.

1. 로그 파일은 전에 따로 얘기했던 대로 플랫폼 독립성을 위해 os.path.join을 이용하도록 했습니다.  getcwd() 같은 경우도 터미널로 실행하냐, 파이참으로 실행하냐 등의 실행환경에 따라 달라질 수 있어서 abspath 활용했습니다.

 
![image](https://user-images.githubusercontent.com/11948404/75982946-f3b1c380-5f2a-11ea-96b2-289ada4a0c45.png)
이런 식으로 log 폴더에 일자별로 로그가 생성됩니다.

2. DB 마이그레이션을 직접 진행하며, 오류가 나오는 부분을 찾으며 리드미도 좀 고쳤습니다. 로컬 DB 세팅이 생각보다 내용이 길어져서 따로 분리했습니다.

+ requirements.txt에 마이그레이션 관련 라이브러리가 추가 안 되어있어서 추가했습니다.